### PR TITLE
TA-28669. Stop saving all rpush IDs to set.

### DIFF
--- a/lib/rpush/client/redis/notification.rb
+++ b/lib/rpush/client/redis/notification.rb
@@ -6,6 +6,8 @@ module Rpush
         include Modis::Model
         include Rpush::Client::ActiveModel::Notification
 
+        enable_all_index false # prevent creation of massive rpush:notifications:all set
+
         after_create :register_notification
 
         self.namespace = 'notifications'


### PR DESCRIPTION
See 'all index' section here: https://github.com/rpush/modis

This is what is causing a massive set (under key rpush:notifications:all) to be created.